### PR TITLE
com.fasterxml.jackson.core vulnerability fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,12 @@ dependencies {
     implementation group: 'com.amazonaws', name: 'aws-lambda-java-log4j2', version: '1.5.1'
     implementation group: 'com.amazonaws', name: 'aws-java-sdk-s3'
     implementation group: 'com.amazonaws', name: 'aws-java-sdk-secretsmanager'
+
+    // Override transitive dependencies within SecretsManager to deal with high priority CVEs.
+    // See https://github.com/flyway/flyway/commit/99dafe14591d8eb9c0025f47be73015ae6ced4ac
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.10.5.1'
+    implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-cbor', version: '2.12.1'
+
     implementation platform("org.testcontainers:testcontainers-bom:${testContainersVersion}")
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'
     testImplementation group: 'org.mockito', name: 'mockito-core', version: '2.+'


### PR DESCRIPTION
This is an additional change to properly fix https://github.com/Geekoosh/flyway-lambda/issues/16.

Although updating to the later flywaydb version removes its dependencies on the vulnerable jackson packages, the vulnerable dependencies are still used by com.amazonaws:aws-java-sdk-secretsmanager and com.amazonaws:aws-java-sdk-s3, which themselves are direct dependencies of flyway-lambda. When the flyway-all uber-jar is built it was still packaging up the vulnerable dependencies.

This change performs the same trick as was introduced in flywaydb version 7.11.1 (https://github.com/flyway/flyway/commit/99dafe14591d8eb9c0025f47be73015ae6ced4ac), namely newer versions of the jackson packages are explicitly included in the dependencies.